### PR TITLE
Rework CI

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,9 +2,9 @@ name: "CodeQL"
 
 on:
   push:
-    branches: dev
+    branches: [ main ]
   pull_request:
-    branches: [master, dev]
+    branches: [ main ]
   schedule:
     - cron: '0 8 * * 3'
 

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x]
+        node-version: [16.x, 17.x]
     name: Build & Lint
     steps:
     - name: Checkout Code

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -2,9 +2,9 @@ name: "Node.js CI"
 
 on:
   push:
-    branches: dev
+    branches: [ main ]
   pull_request:
-    branches: [ master, dev ]
+    branches: [ main ]
 
 jobs:
   build:


### PR DESCRIPTION
This PR

- renames branch `master` to `main`
- removed branch `dev` from CI
- updates Node.js CI to 17.x, while dropping 14.x