### PR TITLE
Fix create-release GitHub action

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -11,7 +11,7 @@ jobs:
 
       - name: Get tag
         run: |
-          echo TAG=$(git log --format=%B -n 1 --no-merges ${{ github.ref }}) | tee -a $GITHUB_ENV
+          echo TAG=$(git log -1 --format='%B' --no-merges) | tee -a $GITHUB_ENV
 
       - name: Create release
         uses: actions/github-script@v5


### PR DESCRIPTION
This PR (hopefully) fixes the create-release GitHub action.
The previous run in https://github.com/n-thumann/IPTV-ReStream/runs/4685333776?check_suite_focus=true#step:3:4 mistakenly ignore the `--no-merges` option for an unknown reason.