### PR TITLE
Increase fetch-depth in create-release GitHub action

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
 
       - name: Get tag
         run: |


### PR DESCRIPTION
This PR increases the fetch-depth when checking out the repo from one to two, to allow the subsequent command to work properly.