### PR TITLE
Don't mark releases as draft in GitHub action

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -24,6 +24,5 @@ jobs:
               repo: context.repo.repo,
               tag_name: "v${{ env.TAG }}",
               name: "IPTV-ReStream v${{ env.TAG }}",
-              draft: true,
               generate_release_notes: true
             })


### PR DESCRIPTION
This PR removes the marking of releases as draft from the create-release GitHub action.