### PR TITLE
Remove image scaling proxy

### DIFF
--- a/src/providers/station.ts
+++ b/src/providers/station.ts
@@ -1,6 +1,5 @@
 import { Station } from '../models/station';
 import { readFile } from 'fs';
-import util from 'util';
 import debug from 'debug';
 
 interface jsonFormat {
@@ -22,14 +21,13 @@ class StationProvider {
                 return;
             }
             const json = JSON.parse(data.toString());
-            const imageProxyFormat = json['imagescalingurl'];
             json['channellist'].forEach((channel: jsonFormat) => {
                 this.stations.push(new Station(
                     `${channel.channel_name} ${channel.media_definition}`,
                     channel.media_multicast_sourceip,
                     channel.media_multicast_ip,
                     channel.media_multicast_port,
-                    util.format(imageProxyFormat, 30, channel.channel_logo))
+                    channel.channel_logo)
                 );
             });
             this.logger('Stations loaded');


### PR DESCRIPTION
Currently, the station images are broken. This is due to https://db.iptv.blog/multicastadressliste.json no longer containing the image scaling proxy URL (`... "mdr.daserste.de"}}],"imagescalingurl":"https://ngiss.t-online.de/iss?client=ngtv&y=%s&ar=keep&src=%s"}`).
This PR therefore removes the image scaling proxy to access the images directly. Previously the images were scaled down by the proxy to 30x30 px (as displayed in the browser) and without it the images are 45x45 px.