### PR TITLE
Add Node.js 18.x to CI

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 17.x]
+        node-version: [16.x, 17.x, 18.x]
     name: Build & Lint
     steps:
     - name: Checkout Code


### PR DESCRIPTION
This PR adds Node.js 18.x to the CI.