### PR TITLE
Inhibit eslint to successfully exit with warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "tsc",
     "build:watch": "tsc --watch",
     "clean": "rm -rf dist/* && rm -rf node_modules",
-    "lint": "eslint . --ext .ts"
+    "lint": "eslint . --ext .ts --max-warnings 0"
   },
   "dependencies": {
     "debug": "^4.3.4",


### PR DESCRIPTION
Currently, it's possible for eslint to have warnings and still exit with code `0`. This causes the CI to pass, even if there are warnings.
This PR therefore sets the `--max-warnings` (see https://eslint.org/docs/user-guide/command-line-interface#--max-warnings) parameter to `0` so that eslint will exit with `1`, if there are any warnings.