### PR TITLE
Add npm audit signatures to Node.js CI

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -22,6 +22,8 @@ jobs:
         node-version: ${{ matrix.node-version }}
     - name: Install Dependencies
       run: npm ci
+    - name: Audit signatures
+      run: npm audit signatures
     - name: Build (Transpile)
       run: npm run build
     - name: Lint


### PR DESCRIPTION
This PR adds signature validation of npm packages to the Node.js CI (see https://docs.npmjs.com/cli/v8/commands/npm-audit)