### PR TITLE
Remove Node.js 17 from CI

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 17.x, 18.x]
+        node-version: [16.x, 18.x]
     name: Build & Lint
     steps:
     - name: Checkout Code


### PR DESCRIPTION
This PR removes Node.js 17 from the CI, since it's EOL (see https://nodejs.org/en/about/releases/).