### PR TITLE
Revert "Bump node from 18-alpine to 19-alpine"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:19-alpine AS builder
+FROM node:18-alpine AS builder
 
 WORKDIR /app
 COPY src ./src/
@@ -7,7 +7,7 @@ COPY tsconfig.json ./
 RUN npm install --only=dev
 RUN npx tsc
 
-FROM node:19-alpine
+FROM node:18-alpine
 WORKDIR /app
 COPY --from=builder /app/dist/ ./dist
 RUN mkdir ./data && wget -P ./data https://db.iptv.blog/multicastadressliste.json


### PR DESCRIPTION
Reverts n-thumann/IPTV-ReStream#181.

The current Node.js v19 Docker image for armv7 seems to be partially broken (https://github.com/n-thumann/IPTV-ReStream/actions/runs/3400430996).
Example:
- `docker run -it --rm arm32v7/node:18-alpine node -v` works
- `docker run -it --rm arm32v7/node:19-alpine node -v` works
- `docker run -it --rm arm32v7/node:18-alpine node -h` works
- `docker run -it --rm arm32v7/node:19-alpine node -h` (and any other command) doesn't work