### PR TITLE
Fix warnings during npm install in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /app
 COPY src ./src/
 COPY package*.json ./
 COPY tsconfig.json ./
-RUN npm install --only=dev
+RUN npm install
 RUN npx tsc
 
 FROM node:18-alpine
@@ -14,7 +14,7 @@ RUN mkdir ./data && wget -P ./data https://db.iptv.blog/multicastadressliste.jso
 COPY package*.json ./
 COPY views/ ./views/
 COPY public/ ./public/
-RUN npm install --only=production
+RUN npm install --omit=dev
 USER node
 
 ENTRYPOINT [ "node", "dist/app.js" ]


### PR DESCRIPTION
This PR fixes two warnings during `npm install` in the Dockerfile, namely:
```
[...]
#10 [builder 6/7] RUN npm install --only=dev
#10 0.453 npm WARN invalid config only="dev" set in command line options
#10 0.453 npm WARN invalid config Must be one of: null, prod, production
[...]
#17 [stage-1 8/8] RUN npm install --only=production
#17 0.512 npm WARN config only Use `--omit=dev` to omit dev dependencies from the install.
[...]
```