### PR TITLE
Refactor Docker image

### DIFF
--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -1,0 +1,18 @@
+version: "3.8"
+services:
+  iptv-restream:
+    image: nthumann/iptv-restream:latest
+    build:
+      context: .
+    network_mode: host
+    restart: always
+    container_name: IPTV-ReStream
+    environment:
+      HOST: "127.0.0.1"
+      PORT: 3000
+      MCAST_IF: "0.0.0.0"
+      XSPF_PROTOCOL: "https"
+      XSPF_HOST: "my.server.com:8080"
+      XSPF_PATH_PREFIX: "/iptv"
+      ALLOW_UNKNOWN: "false"
+      DEBUG: "iptv-restream:*"


### PR DESCRIPTION
This PR refactors the Docker image and adds a example Docker Compose file.
- Use Debian-based Node.js image instead of Alpine (resolves https://github.com/n-thumann/IPTV-ReStream/pull/206, which cannot be merged anyways)
- Improve permissions by consistently using user `node`
- Clean npm cache after installation