### PR TITLE
Bump Node.js versions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 19.x]
+        node-version: [18.x, 20.x]
     name: Build & Lint
     steps:
       - name: Checkout Code
@@ -32,7 +32,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        node-version: [16.x, 18.x, 19.x]
+        node-version: [18.x, 20.x]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies
         run: |
+          sudo apt update
           sudo apt install -y ffmpeg
       - name: Prepare test environment
         run: |


### PR DESCRIPTION
This PR bumps the supported Node.js version by dropping version 16.x (EOL) and 19.x (EOL very soon) and add 20.x to CI.
It also adds an `apt update` that I've missed in https://github.com/n-thumann/IPTV-ReStream/pull/218/.