### PR TITLE
Fix: Broken Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,11 @@ FROM node:20-bullseye-slim
 USER node
 WORKDIR /app
 
-COPY --chown=node:node --from=builder /app/dist/ /app/
+COPY --chown=node:node --from=builder /app/dist/ ./dist/
 ADD --chown=node:node https://db.iptv.blog/multicastadressliste.json ./data/
 COPY --chown=node:node package*.json ./
 COPY --chown=node:node views/ ./views/
 COPY --chown=node:node public/ ./public/
 RUN npm ci --omit=dev && npm cache clean --force
 
-CMD [ "node", "app.js" ]
+CMD [ "node", "dist/app.js" ]


### PR DESCRIPTION
Caused by https://github.com/n-thumann/IPTV-ReStream/pull/219/commits/e0dec720e638d5c45dd62e90f994b60a56267093.
Fixes https://github.com/n-thumann/IPTV-ReStream/issues/238.

The applications expected `views/` to be at `../views/`. During the previous refactoring however, the applications was moved, so that the path no longer matched.