### PR TITLE
Change: Listen on all interfaces + dual stack by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ It's highly recommended running this application behind a Reverse Proxy ([nginx]
 ### Environment Variables
 | Variable | Description |
 | -------- | ----------- |
-| HOST | Web interface Listen Host (default `127.0.0.1`) |
+| HOST | Web interface Listen Host (default: empty to listen on all interfaces) |
 | PORT | Web interface Listen Port (default `3000`) |
 | MCAST_IF | joins the multicast group using this interface (default `0.0.0.0`, lets OS choose automatically) |
 | XSPF_PROTOCOL | Protocol (`http`/`https`) for generating XSPF |

--- a/src/providers/config.ts
+++ b/src/providers/config.ts
@@ -1,6 +1,6 @@
 import debug from 'debug';
 class ConfigProvider {
-    readonly host: string = '';
+    readonly host?: string;
     readonly port: number;
     readonly mcast_if: string = '';
     readonly xspf_protocol: string = '';
@@ -9,7 +9,7 @@ class ConfigProvider {
     readonly allow_unknown: boolean;
 
     constructor() {
-        this.host = process.env.HOST || '127.0.0.1';
+        this.host = process.env.HOST;
         this.port = parseInt(process.env.PORT || '3000');
         this.mcast_if = process.env.MCAST_IF || '0.0.0.0';
         this.xspf_protocol = process.env.XSPF_PROTOCOL || '';


### PR DESCRIPTION
This PR changes the behavior of the web interface to listen on
- all interfaces instead of `127.0.0.1` by default
- both IPv4 and IPv6 by default